### PR TITLE
to roman method pass through number

### DIFF
--- a/lib/check.rb
+++ b/lib/check.rb
@@ -1,6 +1,6 @@
 class String
   def is_hira?
-    return true if self =~ /\p{hiragana}/
+    return true if self =~ /\p{hiragana}|\p{hiragana}[0-9][０-９]/
     false
   end
 
@@ -10,7 +10,7 @@ class String
   end
 
   def is_kana?
-    return true if self =~ /\p{katakana}/
+    return true if self =~ /\p{katakana}|\p{katakana}[0-9][０-９]/
     false
   end
 
@@ -20,7 +20,7 @@ class String
   end
 
   def is_roman?
-    return true if self =~ /^[a-zA-Z]+$/
+    return true if self =~ /^[a-zA-Z0-9]+$/
     false
   end
 end

--- a/lib/format.rb
+++ b/lib/format.rb
@@ -8,7 +8,6 @@ class String
   end
 
   def to_roman
-    binding.pry
     return self if self.is_roman?
     s = self.to_kana
     s.gsub(/[#{s}]/, kana_roman)

--- a/lib/format.rb
+++ b/lib/format.rb
@@ -1,5 +1,3 @@
-require 'mechanize'
-
 class String
   def to_kana
     self.tr('ぁ-ん','ァ-ン')
@@ -10,6 +8,8 @@ class String
   end
 
   def to_roman
+    binding.pry
+    return self if self.is_roman?
     s = self.to_kana
     s.gsub(/[#{s}]/, kana_roman)
   end
@@ -135,6 +135,26 @@ class String
       'フィ' => 'fi',
       'フェ' => 'fe',
       'フォ' => 'fo',
+      '0' => '0',
+      '1' => '1',
+      '2' => '2',
+      '3' => '3',
+      '4' => '4',
+      '5' => '5',
+      '6' => '6',
+      '7' => '7',
+      '8' => '8',
+      '9' => '9',
+      '０' => '0',
+      '１' => '1',
+      '２' => '2',
+      '３' => '3',
+      '４' => '4',
+      '５' => '5',
+      '６' => '6',
+      '７' => '7',
+      '８' => '8',
+      '９' => '9'
     }
   end
 

--- a/miyabi.gemspec
+++ b/miyabi.gemspec
@@ -24,5 +24,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_dependency "mechanize", "2.7.5"
 end

--- a/spec/miyabi/check_spec.rb
+++ b/spec/miyabi/check_spec.rb
@@ -10,8 +10,26 @@ RSpec.describe "check" do
       it { is_expected.to be_truthy }
     end
 
+    context "when hiragana with number" do
+      let(:text) { "ひらがな01234" }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when hiragana with em number" do
+      let(:text) { "ひらがな０１２３４" }
+
+      it { is_expected.to be_truthy }
+    end
+
     context "when romaji" do
       let(:text) { "hiragana" }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when romaji with number" do
+      let(:text) { "hiragana01234" }
 
       it { is_expected.to be_falsey }
     end
@@ -60,6 +78,30 @@ RSpec.describe "check" do
       let(:text) { "katakana" }
 
       it { is_expected.to be_falsey }
+    end
+
+    context "when number" do
+      let(:text) { "0123" }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when katakana with number" do
+      let(:text) { "カキクケコ0123" }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when number" do
+      let(:text) { "０１２３４" }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when katakana with em number" do
+      let(:text) { "カキクケコ０１２３４" }
+
+      it { is_expected.to be_truthy }
     end
 
     context "when includes katakana" do
@@ -131,6 +173,12 @@ RSpec.describe "check" do
     let(:text) { "romaji" }
 
     context "when romaji" do
+      it { is_expected.to be_truthy }
+    end
+
+    context "when includes number" do
+      let(:text) { "romaji0123" }
+
       it { is_expected.to be_truthy }
     end
 

--- a/spec/miyabi/format_spec.rb
+++ b/spec/miyabi/format_spec.rb
@@ -72,6 +72,24 @@ RSpec.describe "format" do
       it { is_expected.to eq "hiragana" }
     end
 
+    context "when romaji with number" do
+      let(:text) { "romaji01234" }
+
+      it { is_expected.to eq text }
+    end
+
+    context "when hiragana with half size number" do
+      let(:text) { "ひらがな01234" }
+
+      it { is_expected.to eq "hiragana01234" }
+    end
+
+    context "when hiragana with em number" do
+      let(:text) { "ひらがな０１２３４" }
+
+      it { is_expected.to eq "hiragana01234" }
+    end
+
     context "when katakana" do
       let(:text) { "カタカナ" }
 

--- a/spec/miyabi/format_spec.rb
+++ b/spec/miyabi/format_spec.rb
@@ -96,6 +96,18 @@ RSpec.describe "format" do
       it { is_expected.to eq "katakana" }
     end
 
+    context "when katakana with number" do
+      let(:text) { "カタカナ01234" }
+
+      it { is_expected.to eq "katakana01234" }
+    end
+
+    context "when katakana with em number" do
+      let(:text) { "カタカナ０１２３４" }
+
+      it { is_expected.to eq "katakana01234" }
+    end
+
     context "when hiragana with katakana" do
       let(:text) { "ひらがなカタカナ" }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 require "bundler/setup"
 require "miyabi"
-require "pry"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "bundler/setup"
 require "miyabi"
+require "pry"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
pass through number katakana and hiragana.
ex. `ひらがな1234` => `hiragana1234`